### PR TITLE
Implement multi-board job scraper

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -1,0 +1,33 @@
+name: Crawl
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  crawl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install deps
+        run: |
+          pip install -r job-hunter/requirements.txt
+      - name: Run scraper
+        env:
+          KEYWORDS: ${{ secrets.KEYWORDS }}
+          MIN_SALARY: ${{ secrets.MIN_SALARY }}
+          RELEVANCE_THRESHOLD: ${{ secrets.RELEVANCE_THRESHOLD }}
+          GREENHOUSE_SLUGS: ${{ secrets.GREENHOUSE_SLUGS }}
+          LEVER_SLUGS: ${{ secrets.LEVER_SLUGS }}
+          ASHBY_SLUGS: ${{ secrets.ASHBY_SLUGS }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: python job-hunter/scraper.py
+      - uses: actions/upload-artifact@v3
+        with:
+          name: jobs
+          path: jobs.db

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,27 @@
+import sqlite3
+import streamlit as st
+
+DB_PATH = 'jobs.db'
+
+st.title('Job Tracker')
+
+conn = sqlite3.connect(DB_PATH)
+rows = conn.execute(
+    'SELECT company, title, location, salary_floor, salary_ceil, similarity, url, updated_at '
+    'FROM jobs ORDER BY updated_at DESC'
+).fetchall()
+conn.close()
+
+min_salary = st.sidebar.number_input('Minimum salary', value=150000)
+min_score = st.sidebar.slider('Min relevance', 0.0, 1.0, 0.75, 0.01)
+
+for r in rows:
+    if r[3] and r[3] < min_salary:
+        continue
+    if r[5] < min_score:
+        continue
+    st.write(f"### {r[1]} @ {r[0]}")
+    st.write(r[2])
+    st.write(f"${r[3]:,}-{r[4]:,} | score {r[5]:.2f}")
+    st.write(f"[Apply]({r[6]})")
+    st.write('---')

--- a/job-hunter/.env
+++ b/job-hunter/.env
@@ -1,9 +1,15 @@
 # keywords that scream “Ian”
 KEYWORDS=forward deployed,solutions architect,gen ai,python,automation,ml
 MIN_SALARY=150000
+RELEVANCE_THRESHOLD=0.75
 
-# company slugs (boards.greenhouse.io/<slug>)
-COMPANIES=palantir,databricks,openai,anduril-industries,tempus
+# board slugs
+GREENHOUSE_SLUGS=palantir,databricks,openai,anduril-industries,tempus
+LEVER_SLUGS=
+ASHBY_SLUGS=
+
+# local resume
+RESUME_FILE=resume.txt
 
 # Slack incoming-webhook URL (create in any workspace → “Incoming Webhooks” app)
 SLACK_WEBHOOK=https://hooks.slack.com/triggers/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

--- a/job-hunter/fetchers.py
+++ b/job-hunter/fetchers.py
@@ -1,0 +1,64 @@
+import requests
+from urllib.parse import quote_plus
+
+
+def fetch_greenhouse(slug: str) -> list:
+    url = f"https://boards-api.greenhouse.io/v1/boards/{quote_plus(slug)}/jobs?content=true"
+    resp = requests.get(url, timeout=20)
+    resp.raise_for_status()
+    jobs = []
+    for j in resp.json().get("jobs", []):
+        jobs.append({
+            "id": str(j["id"]),
+            "board": "greenhouse",
+            "company": slug,
+            "title": j["title"],
+            "location": j.get("location", {}).get("name"),
+            "url": j.get("absolute_url"),
+            "content": j.get("content", ""),
+            "pay_ranges": j.get("pay_input_ranges", []),
+            "updated_at": j.get("updated_at"),
+        })
+    return jobs
+
+
+def fetch_lever(slug: str) -> list:
+    url = f"https://jobs.lever.co/{quote_plus(slug)}?format=json"
+    resp = requests.get(url, timeout=20)
+    resp.raise_for_status()
+    jobs = []
+    for j in resp.json():
+        jobs.append({
+            "id": j.get("id"),
+            "board": "lever",
+            "company": slug,
+            "title": j.get("text"),
+            "location": j.get("categories", {}).get("location"),
+            "url": j.get("hostedUrl"),
+            "content": j.get("description", ""),
+            "pay_ranges": j.get("workplaceType"),
+            "updated_at": j.get("updatedAt"),
+        })
+    return jobs
+
+
+def fetch_ashby(slug: str) -> list:
+    url = f"https://jobs.ashbyhq.com/{quote_plus(slug)}?format=json"
+    resp = requests.get(url, timeout=20)
+    resp.raise_for_status()
+    data = resp.json()
+    postings = data.get("jobs", data)
+    jobs = []
+    for j in postings:
+        jobs.append({
+            "id": j.get("id"),
+            "board": "ashby",
+            "company": slug,
+            "title": j.get("title"),
+            "location": j.get("location"),
+            "url": j.get("url"),
+            "content": j.get("description", ""),
+            "pay_ranges": j.get("pay_range"),
+            "updated_at": j.get("updated_at"),
+        })
+    return jobs

--- a/job-hunter/requirements.txt
+++ b/job-hunter/requirements.txt
@@ -1,5 +1,8 @@
 requests
-python-dotenv       # secrets
-tqdm                # progress bar
-APScheduler         # simple cron
-slack_sdk           # posting alerts
+python-dotenv
+slack_sdk
+sentence-transformers
+openai
+streamlit
+python-docx
+tqdm

--- a/job-hunter/schema.sql
+++ b/job-hunter/schema.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS jobs (
+    id TEXT PRIMARY KEY,
+    board TEXT NOT NULL,
+    company TEXT NOT NULL,
+    title TEXT NOT NULL,
+    location TEXT,
+    url TEXT,
+    salary_floor INTEGER,
+    salary_ceil INTEGER,
+    description TEXT,
+    similarity REAL,
+    updated_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_jobs_similarity ON jobs(similarity);
+CREATE INDEX IF NOT EXISTS idx_jobs_updated ON jobs(updated_at);

--- a/job-hunter/scraper.py
+++ b/job-hunter/scraper.py
@@ -1,102 +1,131 @@
-import os, json, sqlite3, time
-from datetime import datetime, timezone
-from urllib.parse import quote_plus
+import os
+import sqlite3
+from datetime import datetime
 
-import requests
 from dotenv import load_dotenv
 from slack_sdk.webhook import WebhookClient
-from apscheduler.schedulers.blocking import BlockingScheduler
 from tqdm import tqdm
+
+from fetchers import fetch_greenhouse, fetch_lever, fetch_ashby
+from similarity import embed_text, cosine_similarity
 
 load_dotenv()
 
-DB_PATH        = "jobs.db"
-KEYWORDS       = [k.strip().lower() for k in os.getenv("KEYWORDS").split(",")]
-MIN_SALARY     = int(os.getenv("MIN_SALARY", 150000))
-COMPANIES      = [c.strip() for c in os.getenv("COMPANIES").split(",")]
-SLACK_WEBHOOK  = os.getenv("SLACK_WEBHOOK")
+DB_PATH = "jobs.db"
+KEYWORDS = [k.strip().lower() for k in os.getenv("KEYWORDS", "").split(",") if k.strip()]
+MIN_SALARY = int(os.getenv("MIN_SALARY", 150000))
+RELEVANCE_THRESHOLD = float(os.getenv("RELEVANCE_THRESHOLD", 0.75))
+GREENHOUSE_SLUGS = [c.strip() for c in os.getenv("GREENHOUSE_SLUGS", "").split(",") if c.strip()]
+LEVER_SLUGS = [c.strip() for c in os.getenv("LEVER_SLUGS", "").split(",") if c.strip()]
+ASHBY_SLUGS = [c.strip() for c in os.getenv("ASHBY_SLUGS", "").split(",") if c.strip()]
+RESUME_FILE = os.getenv("RESUME_FILE", "resume.txt")
+SLACK_WEBHOOK = os.getenv("SLACK_WEBHOOK")
 
-# -------- helpers ----------------------------------------------------------
+RESUME_EMB = embed_text(open(RESUME_FILE).read()) if os.path.exists(RESUME_FILE) else None
 
-def gh_endpoint(slug: str) -> str:
-    # Greenhouse Job Board API: public JSON – no auth needed ◆ docs :contentReference[oaicite:0]{index=0}
-    return f"https://boards-api.greenhouse.io/v1/boards/{quote_plus(slug)}/jobs?content=true"
 
-def matches(job: dict) -> bool:
-    haystack = f"{job['title']} {job.get('content','')}".lower()
+def keyword_match(job: dict) -> bool:
+    if not KEYWORDS:
+        return True
+    haystack = f"{job['title']} {job.get('content', '')}".lower()
     return any(k in haystack for k in KEYWORDS)
 
-def parse_salary(job: dict):
-    ranges = job.get("pay_input_ranges") or []
+
+def salary_from_ranges(ranges) -> tuple:
     if not ranges:
         return None, None
-    floor = min(r["min_cents"] for r in ranges) // 100
-    ceil  = max(r["max_cents"] for r in ranges) // 100
-    return floor, ceil
+    try:
+        floor = min(int(r.get('min_cents', 0)) for r in ranges) // 100
+        ceil = max(int(r.get('max_cents', 0)) for r in ranges) // 100
+        return floor, ceil
+    except Exception:
+        return None, None
 
-def notify(job):
+
+def notify(job: dict) -> None:
     if not SLACK_WEBHOOK:
         return
-    text = (f"*{job['title']}* @ {job['company']}  \n"
-            f"{job['location']} | ${job['salary_floor']:,}–${job['salary_ceil']:,}  \n"
-            f"<{job['abs_url']}|Apply ➜>")
+    text = (
+        f"*{job['title']}* @ {job['company']}\n"
+        f"{job.get('location','')} | ${job['salary_floor']:,}-{job['salary_ceil']:,}\n"
+        f"<{job['url']}|Apply ➜> (score {job['similarity']:.2f})"
+    )
     WebhookClient(SLACK_WEBHOOK).send(text=text)
 
-# -------- core -------------------------------------------------------------
+
+def persist(conn, job: dict) -> None:
+    with conn:
+        cur = conn.execute("SELECT 1 FROM jobs WHERE id=?", (job['id'],))
+        if cur.fetchone():
+            return
+        conn.execute(
+            """
+            INSERT INTO jobs (id, board, company, title, location, url,
+                              salary_floor, salary_ceil, description,
+                              similarity, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                job['id'], job['board'], job['company'], job['title'],
+                job.get('location'), job.get('url'),
+                job.get('salary_floor'), job.get('salary_ceil'),
+                job.get('content'), job.get('similarity'),
+                job.get('updated_at'),
+            ),
+        )
+
+
+def process_jobs(conn, jobs):
+    for j in jobs:
+        if not keyword_match(j):
+            continue
+        floor, ceil = salary_from_ranges(j.get('pay_ranges'))
+        j['salary_floor'] = floor
+        j['salary_ceil'] = ceil
+        if floor and floor < MIN_SALARY:
+            continue
+        if RESUME_EMB is not None:
+            emb = embed_text(j.get('content', ''))
+            j['similarity'] = cosine_similarity(emb, RESUME_EMB)
+        else:
+            j['similarity'] = 0.0
+        if j['similarity'] < RELEVANCE_THRESHOLD:
+            continue
+        persist(conn, j)
+        notify(j)
+
 
 def crawl_once():
     conn = sqlite3.connect(DB_PATH)
     conn.execute("PRAGMA journal_mode=WAL")
-    conn.executescript(open("schema.sql").read())
+    conn.executescript(open(os.path.join(os.path.dirname(__file__), 'schema.sql')).read())
 
-    for company in tqdm(COMPANIES, desc="Companies"):
+    for slug in tqdm(GREENHOUSE_SLUGS, desc="Greenhouse"):
         try:
-            resp = requests.get(gh_endpoint(company), timeout=20)
-            resp.raise_for_status()
-            jobs = resp.json().get("jobs", [])
+            jobs = fetch_greenhouse(slug)
         except Exception as e:
-            print(f"[WARN] {company}: {e}")
+            print(f"[WARN] {slug}: {e}")
             continue
+        process_jobs(conn, jobs)
 
-        for j in jobs:
-            if not matches(j):
-                continue
-            floor, ceil = parse_salary(j)
-            if floor and floor < MIN_SALARY:
-                continue        # under your target
+    for slug in tqdm(LEVER_SLUGS, desc="Lever"):
+        try:
+            jobs = fetch_lever(slug)
+        except Exception as e:
+            print(f"[WARN] {slug}: {e}")
+            continue
+        process_jobs(conn, jobs)
 
-            # insert if new
-            with conn:
-                cur = conn.execute(
-                    "SELECT 1 FROM jobs WHERE id=?",
-                    (j["id"],)
-                )
-                if cur.fetchone():
-                    continue
-
-                conn.execute("""
-                    INSERT INTO jobs (id, company, title, location, abs_url,
-                                      salary_floor, salary_ceil, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """, (
-                    j["id"], company, j["title"],
-                    j["location"]["name"],
-                    j["absolute_url"],
-                    floor, ceil,
-                    j["updated_at"]
-                ))
-            j.update(company=company, salary_floor=floor, salary_ceil=ceil)
-            notify(j)
+    for slug in tqdm(ASHBY_SLUGS, desc="Ashby"):
+        try:
+            jobs = fetch_ashby(slug)
+        except Exception as e:
+            print(f"[WARN] {slug}: {e}")
+            continue
+        process_jobs(conn, jobs)
 
     conn.close()
 
-# -------- schedule nightly at 9 PM central --------------------------------
-if __name__ == "__main__":
-    crawl_once()  # fire immediately
 
-    sched = BlockingScheduler(timezone="America/Chicago")
-    sched.add_job(crawl_once, "cron", hour=21, minute=0)
-    try:
-        sched.start()
-    except (KeyboardInterrupt, SystemExit):
-        pass
+if __name__ == "__main__":
+    crawl_once()

--- a/job-hunter/similarity.py
+++ b/job-hunter/similarity.py
@@ -1,0 +1,32 @@
+import os
+import numpy as np
+from typing import List
+
+try:
+    import openai
+    OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+    if OPENAI_API_KEY:
+        openai.api_key = OPENAI_API_KEY
+except Exception:  # pragma: no cover - optional
+    openai = None
+
+try:
+    from sentence_transformers import SentenceTransformer
+    _model = SentenceTransformer('all-MiniLM-L6-v2') if not openai else None
+except Exception:  # pragma: no cover - optional
+    _model = None
+
+
+def embed_text(text: str) -> List[float]:
+    if openai and OPENAI_API_KEY:
+        resp = openai.Embedding.create(input=[text], model='text-embedding-ada-002')
+        return resp['data'][0]['embedding']
+    if _model:
+        return _model.encode([text])[0].tolist()
+    raise RuntimeError('No embedding backend available')
+
+
+def cosine_similarity(v1: List[float], v2: List[float]) -> float:
+    a = np.array(v1)
+    b = np.array(v2)
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))

--- a/resume_tailer.py
+++ b/resume_tailer.py
@@ -1,0 +1,32 @@
+import os
+import sqlite3
+from docx import Document
+import openai
+
+DB_PATH = 'jobs.db'
+RESUME_FILE = os.getenv('RESUME_FILE', 'resume.txt')
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+openai.api_key = OPENAI_API_KEY
+
+
+def generate(job_id: str, out_path: str) -> None:
+    conn = sqlite3.connect(DB_PATH)
+    row = conn.execute('SELECT title, company, description FROM jobs WHERE id=?', (job_id,)).fetchone()
+    conn.close()
+    if not row:
+        raise SystemExit('job not found')
+
+    master = open(RESUME_FILE).read()
+    prompt = f"Tailor this resume to the following job:\nJob: {row[0]} at {row[1]}\nDescription:\n{row[2]}\nResume:\n{master}"
+    resp = openai.ChatCompletion.create(model='gpt-3.5-turbo', messages=[{'role':'user','content':prompt}])
+    text = resp['choices'][0]['message']['content']
+
+    doc = Document()
+    for line in text.split('\n'):
+        doc.add_paragraph(line)
+    doc.save(out_path)
+
+
+if __name__ == '__main__':
+    import sys
+    generate(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
## Summary
- support fetching jobs from Greenhouse, Lever, and Ashby
- compute embeddings via OpenAI or sentence-transformers and filter by similarity
- store details in SQLite with new schema
- notify via Slack and offer streamlit dashboard
- generate tailored resumes through GPT
- run crawler on a schedule via GitHub Actions

## Testing
- `python -m py_compile job-hunter/*.py dashboard.py resume_tailer.py`

