### PR TITLE
Add OpenAI key to env example

### DIFF
--- a/job-hunter/.env
+++ b/job-hunter/.env
@@ -13,3 +13,6 @@ RESUME_FILE=resume.txt
 
 # Slack incoming-webhook URL (create in any workspace → “Incoming Webhooks” app)
 SLACK_WEBHOOK=
+
+# OpenAI API key for embeddings and résumé tailoring
+OPENAI_API_KEY=


### PR DESCRIPTION
## Summary
- include `OPENAI_API_KEY` in the example `.env`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843ba9ef3ec8330a6b773e995d869ab