### PR TITLE
Improve ease of running job hunter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ This project scrapes job boards (Greenhouse, Lever and Ashby) and stores roles i
    ```bash
    pip install -r job-hunter/requirements.txt
    ```
-3. Copy `job-hunter/.env` and edit values for your use:
+3. Copy `job-hunter/.env.example` to `job-hunter/.env` and edit values:
    - `KEYWORDS` – comma separated keywords used for simple matching
    - `MIN_SALARY` – discard jobs below this salary floor
    - `RELEVANCE_THRESHOLD` – cosine similarity threshold
    - `GREENHOUSE_SLUGS`, `LEVER_SLUGS`, `ASHBY_SLUGS` – board identifiers
    - `RESUME_FILE` – path to your resume text
    - `SLACK_WEBHOOK` – optional Slack incoming webhook URL
-   - `OPENAI_API_KEY` – required for OpenAI embeddings
+  - `OPENAI_API_KEY` – optional key for OpenAI embeddings
 
 ## Usage
 
@@ -30,7 +30,7 @@ View results in a browser:
 streamlit run dashboard.py
 ```
 
-Generate a tailored résumé for a job id:
+Generate a tailored résumé for a job id (falls back to your unmodified résumé if OpenAI isn't configured):
 ```bash
 python resume_tailer.py <job_id> out.docx
 ```

--- a/job-hunter/.env.example
+++ b/job-hunter/.env.example
@@ -1,0 +1,17 @@
+# keywords that scream “Ian”
+KEYWORDS=forward deployed,solutions architect,gen ai,python,automation,ml
+MIN_SALARY=150000
+RELEVANCE_THRESHOLD=0.75
+
+# board slugs (examples that usually have active listings)
+GREENHOUSE_SLUGS=databricks,stripe,notion
+LEVER_SLUGS=scaleai,runway
+ASHBY_SLUGS=anthropic,gretel-labs
+
+# local resume
+RESUME_FILE=resume.txt
+
+# Slack incoming-webhook URL (create in any workspace → “Incoming Webhooks” app)
+SLACK_WEBHOOK=
+# optional OpenAI key for embeddings
+OPENAI_API_KEY=

--- a/resume_tailer.py
+++ b/resume_tailer.py
@@ -1,12 +1,16 @@
 import os
 import sqlite3
 from docx import Document
-import openai
+try:
+    import openai  # optional
+except Exception:  # pragma: no cover - optional
+    openai = None
 
 DB_PATH = 'jobs.db'
 RESUME_FILE = os.getenv('RESUME_FILE', 'resume.txt')
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
-openai.api_key = OPENAI_API_KEY
+if openai and OPENAI_API_KEY:
+    openai.api_key = OPENAI_API_KEY
 
 
 def generate(job_id: str, out_path: str) -> None:
@@ -17,9 +21,20 @@ def generate(job_id: str, out_path: str) -> None:
         raise SystemExit('job not found')
 
     master = open(RESUME_FILE).read()
-    prompt = f"Tailor this resume to the following job:\nJob: {row[0]} at {row[1]}\nDescription:\n{row[2]}\nResume:\n{master}"
-    resp = openai.ChatCompletion.create(model='gpt-3.5-turbo', messages=[{'role':'user','content':prompt}])
-    text = resp['choices'][0]['message']['content']
+    if openai and OPENAI_API_KEY:
+        prompt = (
+            "Tailor this resume to the following job:\n"
+            f"Job: {row[0]} at {row[1]}\n"
+            f"Description:\n{row[2]}\nResume:\n{master}"
+        )
+        resp = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = resp["choices"][0]["message"]["content"]
+    else:
+        print("OPENAI_API_KEY not set; returning original resume")
+        text = master
 
     doc = Document()
     for line in text.split('\n'):


### PR DESCRIPTION
## Summary
- add `.env.example` with more stable board slugs
- make OpenAI usage optional in `resume_tailer.py`
- clarify setup steps in README

## Testing
- `python -m py_compile resume_tailer.py job-hunter/*.py dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_6843ba9823048330b08a0d0338653a70