### PR TITLE
Add crawler loop mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,19 @@ This project scrapes job boards (Greenhouse, Lever and Ashby) and stores roles i
    - `RESUME_FILE` – path to your resume text
    - `SLACK_WEBHOOK` – optional Slack incoming webhook URL
    - `OPENAI_API_KEY` – required for OpenAI embeddings
+   - `CRAWL_HOURS` – number of hours to loop the crawler (0 to run once)
+   - `CRAWL_INTERVAL` – seconds to wait between crawl iterations
 
 ## Usage
 
-Run the crawler:
+Run the crawler once:
 ```bash
 python job-hunter/scraper.py
+```
+
+Loop the crawler for a given duration:
+```bash
+python job-hunter/scraper.py --duration 8 --interval 600
 ```
 
 View results in a browser:


### PR DESCRIPTION
## Summary
- add `CRAWL_HOURS` and `CRAWL_INTERVAL` env vars
- implement `crawl_loop` and CLI options for running multiple iterations
- document the new options in README

## Testing
- `python -m py_compile job-hunter/scraper.py`
- `pip install -r job-hunter/requirements.txt` *(failed: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6843bae9320883309bd99f743db0933b