### PR TITLE
Add embedding fallback and optional OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,21 @@ This project scrapes job boards (Greenhouse, Lever and Ashby) and stores roles i
    - `GREENHOUSE_SLUGS`, `LEVER_SLUGS`, `ASHBY_SLUGS` – board identifiers
    - `RESUME_FILE` – path to your resume text
    - `SLACK_WEBHOOK` – optional Slack incoming webhook URL
-   - `OPENAI_API_KEY` – required for OpenAI embeddings
+   - `OPENAI_API_KEY` – optional OpenAI key for remote embeddings
+     - If not set, a local transformer model is used and a ~100MB download will occur on first run
+   - `CRAWL_HOURS` – number of hours to loop the crawler (0 to run once)
+   - `CRAWL_INTERVAL` – seconds to wait between crawl iterations
 
 ## Usage
 
-Run the crawler:
+Run the crawler once:
 ```bash
 python job-hunter/scraper.py
+```
+
+Loop the crawler for a given duration:
+```bash
+python job-hunter/scraper.py --duration 8 --interval 600
 ```
 
 View results in a browser:

--- a/job-hunter/similarity.py
+++ b/job-hunter/similarity.py
@@ -3,18 +3,20 @@ import numpy as np
 from typing import List
 
 try:
-    import openai
-    OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-    if OPENAI_API_KEY:
-        openai.api_key = OPENAI_API_KEY
+    import openai  # type: ignore
 except Exception:  # pragma: no cover - optional
     openai = None
 
-try:
-    from sentence_transformers import SentenceTransformer
-    _model = SentenceTransformer('all-MiniLM-L6-v2') if not openai else None
-except Exception:  # pragma: no cover - optional
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if openai and OPENAI_API_KEY:
+    openai.api_key = OPENAI_API_KEY
     _model = None
+else:
+    try:
+        from sentence_transformers import SentenceTransformer
+        _model = SentenceTransformer("all-MiniLM-L6-v2")
+    except Exception:  # pragma: no cover - optional
+        _model = None
 
 
 def embed_text(text: str) -> List[float]:


### PR DESCRIPTION
## Summary
- load sentence-transformers model when `OPENAI_API_KEY` is unset
- explain optional API key and local model download in README

## Testing
- `python -m py_compile job-hunter/scraper.py`
- `python -m py_compile job-hunter/similarity.py`
- `pip install --quiet -r job-hunter/requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6843bae9320883309bd99f743db0933b