### PR TITLE
Fix offline embedding logic

### DIFF
--- a/job-hunter/similarity.py
+++ b/job-hunter/similarity.py
@@ -2,9 +2,10 @@ import os
 import numpy as np
 from typing import List
 
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
 try:
     import openai
-    OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
     if OPENAI_API_KEY:
         openai.api_key = OPENAI_API_KEY
 except Exception:  # pragma: no cover - optional
@@ -12,7 +13,11 @@ except Exception:  # pragma: no cover - optional
 
 try:
     from sentence_transformers import SentenceTransformer
-    _model = SentenceTransformer('all-MiniLM-L6-v2') if not openai else None
+    _model = (
+        SentenceTransformer('all-MiniLM-L6-v2')
+        if not OPENAI_API_KEY or openai is None
+        else None
+    )
 except Exception:  # pragma: no cover - optional
     _model = None
 


### PR DESCRIPTION
## Summary
- load `SentenceTransformer` when OpenAI isn't usable
- fall back to local embeddings when no API key is available

## Testing
- `python - <<'PY'
import sys
sys.path.append('job-hunter')
from similarity import embed_text, _model, openai, OPENAI_API_KEY
print('openai module available:', openai is not None)
print('openai key provided:', bool(OPENAI_API_KEY))
try:
    emb = embed_text('hello world')
    print('embedding length', len(emb))
except Exception as e:
    print('error', e)
print('model loaded:', _model is not None)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6843be14861883309783a75150f193e7